### PR TITLE
Get path to installed extensions.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sqlpkg (0.2.2)
+    sqlpkg (0.2.3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -128,10 +128,6 @@ GEM
     nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.15.5-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.15.5-x86_64-linux)
-      racc (~> 1.4)
     parallel (1.24.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -205,8 +201,6 @@ GEM
     rubyzip (2.3.2)
     sqlite3 (1.6.9)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (1.6.9-arm64-darwin)
-    sqlite3 (1.6.9-x86_64-linux)
     standard (1.32.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,42 @@ bundle exec sqlpkg help
 └────────────────────────────────────────────────┘
 ```
 
+You can get the path to an installed extension using the `Sqlpkg.path_for` method, e.g.:
+
+```ruby
+Sqlpkg.path_for("nalgeon/uuid")
+# => "./.sqlpkg/nalgeon/uuid/uuid.dylib"
+```
+
+You can also use the shorter `.[]` alias:
+
+```ruby
+Sqlpkg["nalgeon/uuid"]
+# => "./.sqlpkg/nalgeon/uuid/uuid.dylib"
+```
+
+If you try to access an extension that hasn't been installed, a `Sqlpkg::ExtensionNotInstalledError` will be raised:
+
+```ruby
+Sqlpkg["nalgeon/ulid"]
+# raises Sqlpkg::ExtensionNotInstalledError
+```
+
+This feature is particulary useful for the [new Rails feature](https://github.com/rails/rails/pull/53827) and [`sqlite3-ruby` feature](https://github.com/sparklemotion/sqlite3-ruby/pull/586) that allows automatically loading extensions via the `extensions` keyword defined in the Rails `config/database.yml` or the `SQLite3::Database.new` method call. You can now use either:
+
+```yaml
+development:
+  adapter: sqlite3
+  extensions:
+    - <%= Sqlpkg.path_for("asg017/ulid") %>
+```
+
+or if you are using `SQLite3::Database` directly:
+
+```ruby
+db = SQLite3::Database.new(":memory:", extensions: [Sqlpkg.path_for("asg017/ulid")])
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/sqlpkg.rb
+++ b/lib/sqlpkg.rb
@@ -1,6 +1,35 @@
 # frozen_string_literal: true
 
 module Sqlpkg
+  DIR = ".sqlpkg"
+  FILE_PATTERN = "*.{dylib,so,dll}"
+
+  Error = Class.new(StandardError)
+  ExtensionNotInstalledError = Class.new(Error)
+
+  class << self
+    # File path for identified extension
+    # => "./.sqlpkg/nalgeon/uuid/uuid.dylib"
+    def path_for(identifier)
+      path_glob = File.join(file_dir, identifier, FILE_PATTERN)
+      path = Dir.glob(path_glob).first
+
+      path || raise(ExtensionNotInstalledError, "No extension found for identifier: #{identifier}")
+    end
+    alias_method :[], :path_for
+
+    # The directory where `sqlpkg` stores installed extensions
+    # => "./.sqlpkg"
+    def file_dir
+      File.join(__dir__, DIR)
+    end
+
+    # List of file paths for all installed extensions
+    # => ["./.sqlpkg/asg017/ulid/ulid0.dylib", "./.sqlpkg/nalgeon/uuid/uuid.dylib"]
+    def installed_extension_paths
+      Dir.glob File.join(file_dir, "**", FILE_PATTERN)
+    end
+  end
 end
 
 require_relative "sqlpkg/version"

--- a/test/test_sqlpkg.rb
+++ b/test/test_sqlpkg.rb
@@ -6,4 +6,30 @@ class TestSqlpkg < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Sqlpkg::VERSION
   end
+
+  def test_path_for_when_glob_returns_paths
+    path = "./.sqlpkg/nalgeon/uuid/uuid.dylib"
+    Dir.stub :glob, [path] do
+      assert_equal path, Sqlpkg.path_for("nalgeon/uuid")
+    end
+  end
+
+  def test_path_for_when_glob_returns_empty_array
+    assert_raises Sqlpkg::ExtensionNotInstalledError do
+      Sqlpkg.path_for("nalgeon/uuid")
+    end
+  end
+
+  def test_accessor_when_glob_returns_paths
+    path = "./.sqlpkg/nalgeon/uuid/uuid.dylib"
+    Dir.stub :glob, [path] do
+      assert_equal path, Sqlpkg["nalgeon/uuid"]
+    end
+  end
+
+  def test_accessor_when_glob_returns_empty_array
+    assert_raises Sqlpkg::ExtensionNotInstalledError do
+      Sqlpkg["nalgeon/uuid"]
+    end
+  end
 end


### PR DESCRIPTION
In order for this gem to work seamlessly with new features added to the `sqlite3-ruby` gem (see https://github.com/sparklemotion/sqlite3-ruby/pull/586) and `rails` (see https://github.com/rails/rails/pull/53827) that make loading extensions easier, this gem needs to provide Ruby constants for any and all installed extensions that respond to the `.to_path` method. 

Since only installed extensions should have constants, constants need to be dynamically defined. This PR adds a `const_missing` hook to dynamically resolve extension constants for installed extensions.

cc @flavorjones @rossta